### PR TITLE
Initrd create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .idea/
 *.hex
 0bt-install
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ include Makefile.common
 VERSION = "0.0.1"
 IMG_MAKEFILE=--makefile=mk/Makefile.img
 
-$(DEFAULT): $(BUILD_BOOTLOADER) $(BUILD_IMAGE)
+#$(DEFAULT): $(BUILD_BOOTLOADER) $(BUILD_IMAGE)
+$(DEFAULT): INITRD
 
 $(BUILD_IMAGE):
 	@$(MAKE) $(MAKE_FLAGS) $(IMG_MAKEFILE) TOPDIR=$(shell pwd)
@@ -37,9 +38,14 @@ $(INSTALL):
 	dd if=src/x86_64/boot0_x86_64.bin of=disk.img conv=notrunc bs=446 count=1
 	dd if=src/x86_64/boot0_x86_64.bin of=disk.img conv=notrunc skip=1 count=1 seek=1 ibs=512
 
+INITRD:
+	@echo Creating initrd
+	@$(MAKE) $(MAKE_FLAGS) -C initrd TOPDIR=$(shell pwd)
+
 $(CLEAN):
 	@$(MAKE) $(MAKE_FLAGS) -C src/ TOPDIR=$(shell pwd) $@
 	@$(MAKE) $(MAKE_FLAGS) $(IMG_MAKEFILE) TOPDIR=$(shell pwd) $@
+	@$(MAKE) $(MAKE_FLAGS) -C initrd TOPDIR=$(shell pwd) $@
 
 $(HELP):
 	@echo "Common build targets:"

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,7 @@ include Makefile.common
 VERSION = "0.0.1"
 IMG_MAKEFILE=--makefile=mk/Makefile.img
 
-#$(DEFAULT): $(BUILD_BOOTLOADER) $(BUILD_IMAGE)
-$(DEFAULT): INITRD
+$(DEFAULT): $(BUILD_BOOTLOADER) $(BUILD_IMAGE)
 
 $(BUILD_IMAGE):
 	@$(MAKE) $(MAKE_FLAGS) $(IMG_MAKEFILE) TOPDIR=$(shell pwd)

--- a/Makefile.common
+++ b/Makefile.common
@@ -88,3 +88,10 @@ else
 	QUIET_DISC_CREATE=
 	MAKE_FLAGS=
 endif
+
+#
+#set CXX
+#
+ifndef CXX 
+	CXX = g++
+endif

--- a/initrd/Makefile
+++ b/initrd/Makefile
@@ -1,0 +1,8 @@
+
+.DEFAULT_GOAL: CREATE_INIT
+
+CREATE_INIT:
+	./initrd.sh $(TOPDIR) >/dev/null 2>&1
+
+clean:
+	rm -rf $(TOPDIR)/initrd/sbin $(TOPDIR)/initrd/bin/ $(TOPDIR)/initrd/dev/ $(TOPDIR)/initrd/etc/ $(TOPDIR)/initrd/lib/ $(TOPDIR)/initrd/proc/ $(TOPDIR)/initrd/sys/ $(TOPDIR)/initrd/initrd.img $(TOPDIR)/initrd.img

--- a/initrd/init
+++ b/initrd/init
@@ -1,0 +1,8 @@
+#!/bin/ash
+mount -t proc /proc /proc
+mount -t sysfs none /sys
+echo
+echo "initrd is running"
+echo "Using BusyBox..."
+echo
+exec /bin/ash –login

--- a/initrd/initrd.sh
+++ b/initrd/initrd.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+pushd $1/initrd
+
+mkdir {bin,sys,dev,proc,etc,lib}
+
+#fetch busybox as static lib
+pushd bin
+
+wget https://busybox.net/downloads/binaries/1.21.1/busybox-x86_64 -O busybox
+chmod +x busybox
+
+ln -s busybox ash
+ln -s busybox mount
+ln -s busybox echo
+ln -s busybox ls
+ln -s busybox cat
+ln -s busybox ps
+ln -s busybox dmesg
+ln -s busybox sysctl
+ln -s busybox sh
+popd
+
+sudo mknod dev/ram0 b 1 1
+sudo mknod dev/null c 1 3
+sudo mknod dev/tty1 c 4 1
+sudo mknod dev/tty2 c 4 2
+
+ln -s bin sbin
+
+find . | cpio -o -H newc | gzip > initrd.img
+
+cp initrd.img $1/initrd.img

--- a/tools/0bt-install.cpp
+++ b/tools/0bt-install.cpp
@@ -11,7 +11,7 @@
 
 using namespace std;
 
-static const char *default_disk_namge = "disk.img";
+static const char *default_disk_image = "disk.img";
 
 static void usage() {
 	cout << "0bt-install Ver - " << VERSION << endl;


### PR DESCRIPTION
Hi,
    In this branch, I have added a target to create init ram disk. I need your suggestion on this branch. I have tested the created initrd with the kernel using the following command.

`qemu-system-x86_64 -kernel ~/git/linux-1/arch/x86_64/boot/bzImage -initrd initrd.img`

Here I didn't use an hda. I think i have to add that part in init script.

Thanks